### PR TITLE
Added matching for consumer already started

### DIFF
--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -285,6 +285,7 @@ defmodule KafkaEx.ConsumerGroup do
     )
 
     case Supervisor.start_child(pid, child) do
+      {:error, {:already_started, consumer_pid}} -> {:ok, consumer_pid}
       {:ok, consumer_pid} -> {:ok, consumer_pid}
       {:ok, consumer_pid, _info} -> {:ok, consumer_pid}
     end


### PR DESCRIPTION
**Problem:**
Exception is thrown on dev environment:
```elixir
2017-12-18T10:40:40.811015+00:00 app[worker.1]: ** (CaseClauseError) no case clause matching: {:error, {:already_started, #PID<0.3585.0>}}
2017-12-18T10:40:40.811016+00:00 app[worker.1]:     (kafka_ex) lib/kafka_ex/consumer_group.ex:269: KafkaEx.ConsumerGroup.start_consumer/5
2017-12-18T10:40:40.811017+00:00 app[worker.1]:     (kafka_ex) lib/kafka_ex/consumer_group/manager.ex:394: KafkaEx.ConsumerGroup.Manager.start_consumer/2
2017-12-18T10:40:40.811018+00:00 app[worker.1]:     (kafka_ex) lib/kafka_ex/consumer_group/manager.ex:280: KafkaEx.ConsumerGroup.Manager.sync/2
2017-12-18T10:40:40.811019+00:00 app[worker.1]:     (kafka_ex) lib/kafka_ex/consumer_group/manager.ex:153: KafkaEx.ConsumerGroup.Manager.handle_info/2
2017-12-18T10:40:40.811019+00:00 app[worker.1]:     (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
2017-12-18T10:40:40.811020+00:00 app[worker.1]:     (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
2017-12-18T10:40:40.811020+00:00 app[worker.1]:     (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
2017-12-18T10:40:40.811021+00:00 app[worker.1]: Last message: :timeout
2017-12-18T10:40:40.811025+00:00 app[worker.1]: State: %KafkaEx.ConsumerGroup.Manager.State{assignments: nil, consumer_module: Consumer.TokenFlow.CleanUp, consumer_opts: [commit_interval: 5000], consumer_supervisor_pid: nil, generation_id: nil, group_name: "token_cleanup_group", heartbeat_interval: 3000, heartbeat_timer: nil, leader_id: nil, member_id: nil, members: nil, partition_assignment_callback: &KafkaEx.ConsumerGroup.PartitionAssignment.round_robin/2, session_timeout: 15000, supervisor_pid: #PID<0.562.0>, topics: ["raw_token_update_requests"], worker_name: #PID<0.3584.0>}
``` 

**Fix:**
Added pattern matching condition for starting an already started consumer.
